### PR TITLE
Fix block parsing for fenced code blocks in lists

### DIFF
--- a/block.go
+++ b/block.go
@@ -1181,6 +1181,7 @@ gatherlines:
 					codeBlockMarker = marker
 				} else {
 					// end of codeblock.
+					*flags |= LIST_ITEM_CONTAINS_BLOCK
 					codeBlockMarker = ""
 				}
 			}

--- a/block_test.go
+++ b/block_test.go
@@ -1600,10 +1600,10 @@ func TestListWithMalformedFencedCodeBlock(t *testing.T) {
 	// See russross/blackfriday#372 for context.
 	var tests = []string{
 		"1. one\n\n    ```\n    code\n\n2. two\n",
-		"<ol>\n<li>one\n```\ncode\n2. two</li>\n</ol>\n",
+		"<ol>\n<li>one\n\n```\ncode\n\n2. two</li>\n</ol>\n",
 
 		"1. one\n\n    ```\n    - code\n\n2. two\n",
-		"<ol>\n<li>one\n```\n- code\n2. two</li>\n</ol>\n",
+		"<ol>\n<li>one\n\n```\n- code\n\n2. two</li>\n</ol>\n",
 	}
 	doTestsBlock(t, tests, EXTENSION_FENCED_CODE)
 }


### PR DESCRIPTION
Sent a message in https://github.com/russross/blackfriday/issues/239 but here's the synopsis again:

Looks like `TestFencedCodeBlockWithinList` is a test which is in v1 but not v2. It's testing a fenced code block if there is one item in a list. Looks like this has caught an edge case with your fix where the output is different from what is expected.

I believe this input:

    * Foo

        ```
        Hello
        ```

should produce this output:

```html
<ul>
<li><p>Foo</p>

<pre><code>Hello
</code></pre></li>
</ul>
```

However it is producing this:

```html
<ul>
<li>Foo

<code>
Hello
</code></li>
</ul>
```

It looks like this is because the `LIST_ITEM_CONTAINS_BLOCK` flag is never set so the list item is run through the inline parser instead of the block parser. See here: https://github.com/client9/blackfriday/blob/d68ad860fb6ced29d8a9448e3da5aa8ad7efa145/block.go#L1279

I've opened a PR to your repo to set the `LIST_ITEM_CONTAINS_BLOCK` flag if there is a fenced code block in a list item. 

As for the `TestListWithMalformedFencedCodeBlock` test, as @rtfb mentioned in #372 this is undefined behavior and it should be okay as long as it doesn't cut off content. Looks like it's just outputting more newlines so in my PR I just change the expected output of the test.

**Extra Note:** The `LIST_ITEM_CONTAINS_BLOCK` flag is set at the end of the code block as this produces slightly cleaner output for unclosed code blocks.